### PR TITLE
feat: add rsbuild-plugin-cdn-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Rspack and Rsbuild support most of the webpack loaders, such as:
 - [rsbuild-plugin-arethetypeswrong](https://github.com/colinaaa/rsbuild-plugin-arethetypeswrong): Checking TypeScript type definitions with `arethetypeswrong`.
 - [zephyr-rsbuild-plugin](https://www.npmjs.com/package/zephyr-rsbuild-plugin): An Rsbuild plugin for deploying applications with Zephyr Cloud.
 - [rsbuild-plugin-protobufjs](https://github.com/baranwang/rsbuild-plugin-protobufjs): An Rsbuild plugin that integrates `protobufjs`.
+- [rsbuild-plugin-cdn-import](https://github.com/fuxichen/rsbuild-plugin-cdn-import): Import modules from CDN with rsbuild plugin
 
 ### Rspress Plugins
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Rspack and Rsbuild support most of the webpack loaders, such as:
 - [rsbuild-plugin-arethetypeswrong](https://github.com/colinaaa/rsbuild-plugin-arethetypeswrong): Checking TypeScript type definitions with `arethetypeswrong`.
 - [zephyr-rsbuild-plugin](https://www.npmjs.com/package/zephyr-rsbuild-plugin): An Rsbuild plugin for deploying applications with Zephyr Cloud.
 - [rsbuild-plugin-protobufjs](https://github.com/baranwang/rsbuild-plugin-protobufjs): An Rsbuild plugin that integrates `protobufjs`.
-- [rsbuild-plugin-cdn-import](https://github.com/fuxichen/rsbuild-plugin-cdn-import): Import modules from CDN with rsbuild plugin
+- [rsbuild-plugin-cdn-import](https://github.com/fuxichen/rsbuild-plugin-cdn-import): Import modules from CDN with Rsbuild plugin.
 
 ### Rspress Plugins
 


### PR DESCRIPTION
feat: add rsbuild-plugin-cdn-import

新增 rsbuild-plugin-cdn-import 插件
迁移 [vite-plugin-cdn-import](https://github.com/MMF-FE/vite-plugin-cdn-import/tree/5c7a3c06178f8b70693ff30279b85ef7a6fb39ef) 插件为 rsbuild 版本
允许指定 modules 在生产环境中使用 CDN 引入。
这可以减少构建时间,并且提高生产环境中页面加载速度。